### PR TITLE
Add FOSSA workflow to enable license scanning

### DIFF
--- a/.github/workflows/fossa-license-scan.yml
+++ b/.github/workflows/fossa-license-scan.yml
@@ -1,0 +1,24 @@
+# More information on this workflow can be found here: https://stackoverflow.com/c/intercom/questions/1270
+
+name: FOSSA License Scan
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  fossa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Attempt build
+        uses: intercom/attempt-build-action@main
+        continue-on-error: true
+      - name: Run FOSSA
+        uses: intercom/fossa-action@main
+        with:
+          fossa-api-key: ${{ secrets.FOSSA_API_KEY }}
+          fossa-event-receiver-token: ${{ secrets.FOSSA_EVENT_RECEIVER_TOKEN }}
+          datadog-api-key: ${{ secrets.DATADOG_API_KEY }}


### PR DESCRIPTION
# What you need to know
FOSSA is a tool for scanning a repository to ensure that its dependencies are properly licensed. License scanning is a requirement from Legal and needs to be run in all of the repositories we use that have third-party dependencies. This is an automatic PR that adds a new GitHub Actions workflow which will run FOSSA using [`fossa-cli`](https://github.com/fossas/fossa-cli).

This will run parallelly in GitHub Actions whenever there is a push to the `main`/`master` branch and will not block deployments. If the FOSSA action detects any licensing issues it will open an issue in GitHub to team-cloud retrospectively.

# You should probably approve this PR, unless...
FOSSA license scans are only necessary if the repository will contain a language which is supported by FOSSA. The languages supported by FOSSA are listed [here](https://docs.fossa.com/docs/supported-languages).

If this repository will not contain code in any of the above languages or doesn't have any third-party dependencies (for example if the repository only contains data or runbooks), you should add this repository to the [FOSSA ignore list](https://github.com/intercom/github-management-service/blob/master/app/lib/event_management_system/scheduled_tasks/repository_monitoring/fossa-repo-ignore-list.txt) and this PR can be closed.

Alternatively if this repository is a gem repository, this also will not require FOSSA as the FOSSA scan will occur in whatever repositories actually use the gem.

**NOTE:** If this repository is not added to the ignore list, this will be re-opened.

# Additional info
The `fossa.yml` workflow will be run on every push to the `main`/`master` branch, and will first crudely attempt to build the code in the repository using the [`attempt-build-action`](https://github.com/intercom/attempt-build-action) GitHub action, and whether or not that succeeds it will then run the [`fossa-action`](https://github.com/intercom/fossa-action) GitHub action. FOSSA analysis will be more accurate if the project is built before running it, but a successful build is not strictly necessary. If there are errors running `fossa analyze`, the `fossa.yml` workflow can be modified to add custom build steps in place of running `attempt-build-action`. Errors running FOSSA analysis can be checked here (fossa.analyze.exit_code > 0).